### PR TITLE
add test_request parameter for selected endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ BEDbaseR.Rproj
 .httr-oauth
 /doc/
 /Meta/
+
+.DS_Store

--- a/R/bedbaser.R
+++ b/R/bedbaser.R
@@ -292,6 +292,7 @@ bb_example <- function(bedbase, rec_type = c("bed", "bedset")) {
 #' @param id integer(1) record or object identifier
 #' @param full logical(1) (default \code{FALSE}) include full record with
 #' stats, files, and metadata
+#' @param test_request boolean() (default \code{FALSE}) internal parameter for testing purposes
 #'
 #' @return list() metadata
 #'
@@ -305,7 +306,7 @@ bb_example <- function(bedbase, rec_type = c("bed", "bedset")) {
 #' bb_metadata(bedbase, ex_bedset$id)
 #'
 #' @export
-bb_metadata <- function(bedbase, id, full = FALSE) {
+bb_metadata <- function(bedbase, id, full = FALSE, test_request = FALSE) {
     rsp <- bedbase$get_bed_metadata_v1_bed__bed_id__metadata_get(
         bed_id = id,
         full = full
@@ -313,7 +314,8 @@ bb_metadata <- function(bedbase, id, full = FALSE) {
     if (rsp$status_code != 200) {
         rsp <- bedbase$get_bedset_metadata_v1_bedset__bedset_id__metadata_get(
             bedset_id = id,
-            full = full
+            full = full,
+            test_request = test_request,
         )
     }
     result <- httr::content(rsp)
@@ -379,6 +381,7 @@ bb_list_beds <- function(bedbase, genome = NULL, bed_compliance = NULL,
 #' @param query character() (default \code{""}) keyword
 #' @param limit integer(1) (default \code{1000}) maximum records
 #' @param offset integer(1) (default \code{0}) page token of records
+#' @param test_request boolean() (default \code{FALSE}) internal parameter for testing purposes
 #'
 #' @return [tibble][tibble::tibble] of BEDset records
 #'
@@ -387,11 +390,12 @@ bb_list_beds <- function(bedbase, genome = NULL, bed_compliance = NULL,
 #' bb_list_bedsets(bedbase)
 #'
 #' @export
-bb_list_bedsets <- function(bedbase, query = "", limit = 1000, offset = 0) {
+bb_list_bedsets <- function(bedbase, query = "", limit = 1000, offset = 0, test_request = FALSE) {
     rsp <- bedbase$list_bedsets_v1_bedset_list_get(
         query = query,
         limit = limit,
-        offset = offset
+        offset = offset,
+        test_request = test_request
     )
     recs <- httr::content(rsp)
     results <- tibble::tibble()
@@ -460,6 +464,7 @@ bb_beds_in_bedset <- function(bedbase, bedset_id) {
 #' @param assay character() (default NULL) assay to search
 #' @param limit integer(1) (default \code{10}) maximum number of results
 #' @param offset integer(1) (default \code{0}) page offset of results
+#' @param test_request boolean() (default \code{FALSE}) internal parameter for testing purposes
 #'
 #' @return [tibble][tibble::tibble] of results
 #'
@@ -469,7 +474,7 @@ bb_beds_in_bedset <- function(bedbase, bedset_id) {
 #'
 #' @export
 bb_bed_text_search <- function(bedbase, query, genome = NULL, assay = NULL,
-                               limit = 10, offset = 0) {
+                               limit = 10, offset = 0, test_request = FALSE) {
     query <- utils::URLencode(query, reserved = TRUE)
     if (!is.null(genome))
         genome <- utils::URLencode(genome, reserved = TRUE)
@@ -480,7 +485,8 @@ bb_bed_text_search <- function(bedbase, query, genome = NULL, assay = NULL,
         genome = genome,
         assay = assay,
         limit = limit,
-        offset = offset
+        offset = offset,
+        test_request = test_request
     )
     recs <- httr::content(rsp)
     results <- tibble::tibble()

--- a/inst/service/bedbase/README.md
+++ b/inst/service/bedbase/README.md
@@ -26,3 +26,15 @@ Convert openapi.json from OpenAPI 3.1 to 3.0:
 Convert from OpenAPI 3.0 to Swagger 2.0:
 
     api-spec-converter -f openapi_3 -t swagger_2 openapi_3_0.json > api.yaml
+
+### Development Note:
+
+The following endpoints take a hidden parameter `test_request` for internal testing purposes:
+
+- bed_metadata
+- bed_text_to_bed_search
+- bedset_metadata
+- bed_set_search
+- downloading files
+
+The `test_request` is TRUE, the request will not be counted in statistics. 

--- a/inst/service/bedbase/api.yaml
+++ b/inst/service/bedbase/api.yaml
@@ -369,6 +369,13 @@
             "name": "offset",
             "required": false,
             "type": "integer"
+          },
+          {
+            "default": false,
+            "in": "query",
+            "name": "test_request",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {
@@ -532,6 +539,13 @@
             "in": "query",
             "name": "full",
             "required": false
+          },
+          {
+            "default": false,
+            "in": "query",
+            "name": "test_request",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {
@@ -1031,6 +1045,13 @@
             "name": "offset",
             "required": false,
             "type": "integer"
+          },
+          {
+            "default": false,
+            "in": "query",
+            "name": "test_request",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {
@@ -1107,6 +1128,13 @@
             "default": true,
             "in": "query",
             "name": "full",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "default": false,
+            "in": "query",
+            "name": "test_request",
             "required": false,
             "type": "boolean"
           }
@@ -1390,6 +1418,13 @@
             "name": "file_path",
             "required": true,
             "type": "string"
+          },
+          {
+            "default": false,
+            "in": "query",
+            "name": "test_request",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {

--- a/man/bb_bed_text_search.Rd
+++ b/man/bb_bed_text_search.Rd
@@ -10,7 +10,8 @@ bb_bed_text_search(
   genome = NULL,
   assay = NULL,
   limit = 10,
-  offset = 0
+  offset = 0,
+  test_request = FALSE
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ bb_bed_text_search(
 \item{limit}{integer(1) (default \code{10}) maximum number of results}
 
 \item{offset}{integer(1) (default \code{0}) page offset of results}
+
+\item{test_request}{boolean() (default \code{FALSE}) internal parameter for testing purposes}
 }
 \value{
 \link[tibble:tibble]{tibble} of results

--- a/man/bb_list_bedsets.Rd
+++ b/man/bb_list_bedsets.Rd
@@ -4,7 +4,13 @@
 \alias{bb_list_bedsets}
 \title{List BEDsets}
 \usage{
-bb_list_bedsets(bedbase, query = "", limit = 1000, offset = 0)
+bb_list_bedsets(
+  bedbase,
+  query = "",
+  limit = 1000,
+  offset = 0,
+  test_request = FALSE
+)
 }
 \arguments{
 \item{bedbase}{BEDbase() object}
@@ -14,6 +20,8 @@ bb_list_bedsets(bedbase, query = "", limit = 1000, offset = 0)
 \item{limit}{integer(1) (default \code{1000}) maximum records}
 
 \item{offset}{integer(1) (default \code{0}) page token of records}
+
+\item{test_request}{boolean() (default \code{FALSE}) internal parameter for testing purposes}
 }
 \value{
 \link[tibble:tibble]{tibble} of BEDset records

--- a/man/bb_metadata.Rd
+++ b/man/bb_metadata.Rd
@@ -4,7 +4,7 @@
 \alias{bb_metadata}
 \title{Get metadata for a BED file or BEDset}
 \usage{
-bb_metadata(bedbase, id, full = FALSE)
+bb_metadata(bedbase, id, full = FALSE, test_request = FALSE)
 }
 \arguments{
 \item{bedbase}{BEDbase() object}
@@ -13,6 +13,8 @@ bb_metadata(bedbase, id, full = FALSE)
 
 \item{full}{logical(1) (default \code{FALSE}) include full record with
 stats, files, and metadata}
+
+\item{test_request}{boolean() (default \code{FALSE}) internal parameter for testing purposes}
 }
 \value{
 list() metadata

--- a/man/bedbaser-package.Rd
+++ b/man/bedbaser-package.Rd
@@ -17,7 +17,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Andres Wokaty \email{jennifer.wokaty@sph.cuny.edu} (\href{https://orcid.org/0009-0008-0900-8793}{ORCID})
+\strong{Maintainer}: Andres Wokaty \email{andres.wokaty@sph.cuny.edu} (\href{https://orcid.org/0009-0008-0900-8793}{ORCID})
 
 Authors:
 \itemize{

--- a/tests/testthat/test-bedbaser.R
+++ b/tests/testthat/test-bedbaser.R
@@ -18,14 +18,14 @@ test_that("bb_example has 'bed_ids' given rec_type 'bedset'", {
 })
 
 test_that("bb_metadata returns metadata for BEDs", {
-    ex_metadata <- httr::content(bedbase$get_bed_metadata_v1_bed__bed_id__metadata_get(ex_bed$id, TRUE))
-    bed_metadata <- bb_metadata(bedbase, ex_bed$id, TRUE)
+    ex_metadata <- httr::content(bedbase$get_bed_metadata_v1_bed__bed_id__metadata_get(ex_bed$id, TRUE, test_request = TRUE))
+    bed_metadata <- bb_metadata(bedbase, ex_bed$id, TRUE, test_request = TRUE)
     expect_identical(ex_metadata, bed_metadata)
 })
 
 test_that("bb_metadata returns metadata for BEDsets", {
-    ex_bedset_metadata <- httr::content(bedbase$get_bedset_metadata_v1_bedset__bedset_id__metadata_get(ex_bedset$id, TRUE))
-    bedset_metadata <- bb_metadata(bedbase, ex_bedset$id, TRUE)
+    ex_bedset_metadata <- httr::content(bedbase$get_bedset_metadata_v1_bedset__bedset_id__metadata_get(ex_bedset$id, TRUE, test_request = TRUE))
+    bedset_metadata <- bb_metadata(bedbase, ex_bedset$id, TRUE, test_request = TRUE)
     expect_identical(ex_bedset_metadata, bedset_metadata)
 })
 
@@ -49,13 +49,14 @@ test_that("bb_list_beds returns same number of results for the mm39 genome", {
 test_that("bb_list_bedsets returns same number for query 'alzheimer'", {
     bedsets_raw <- httr::content(bedbase$list_bedsets_v1_bedset_list_get(
         query = "alzheimer",
-        limit = 5000
+        limit = 5000,
+        test_request = TRUE
     ))
     bedsets_names_bed_ids_list <- lapply(bedsets_raw$results, `[`, c("id", "bed_ids"))
     bedsets_from_raw <- dplyr::bind_rows(bedsets_names_bed_ids_list) |>
         tidyr::unnest(cols = c(bed_ids))
     bedset_ids <- bedsets_from_raw$id |> unique()
-    bedsets <- bb_list_bedsets(bedbase, query = "alzheimer", limit = 5000)
+    bedsets <- bb_list_bedsets(bedbase, query = "alzheimer", limit = 5000, test_request = TRUE)
     expect_equal(bedset_ids, bedsets$id)
 })
 
@@ -82,14 +83,15 @@ test_that("bb_beds_in_bedset returns expected bed_ids", {
 })
 
 test_that("bb_bed_text_search returns results scored against the query", {
-    beds <- bb_bed_text_search(bedbase, "hg38") |>
+    beds <- bb_bed_text_search(bedbase, "hg38", test_request = TRUE) |>
         dplyr::arrange(id)
     ex_beds <- httr::content(bedbase$text_to_bed_search_v1_bed_search_text_get(
         query = "hg38",
         genome = NULL,
         assay = NULL,
         limit = 10,
-        offset = 0
+        offset = 0,
+        test_request = TRUE
     ))
     ex_beds <- purrr::map_depth(.x = ex_beds$results, 1, \(y) unlist(y)) |>
         dplyr::bind_rows() |>


### PR DESCRIPTION
Per issue databio/bedhost#229, we have a few endpoints with a hidden `test_request` parameter so that test requests don't get counted towards search and usage statistics. This PR includes adds that parameter for the selected endpoints, but I wasn't sure how you would want to handle automatically adding this parameter to openapi.yaml because it doesn't show up in the openapi.json spec (because of `include_in_schema=False`).