### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,20 +2,13 @@ Package: bedbaser
 Title: A BEDbase client
 Version: 1.3.6
 Authors@R: c(
-    person(
-        given = "Andres",
-        family = "Wokaty",
-        role = c("aut", "cre"),
-        email = "andres.wokaty@sph.cuny.edu",
-        comment = c(ORCID = "0009-0008-0900-8793")
-    ),
-    person(
-        given = "Levi",
-        family = "Waldron",
-        role = c("aut"),
-        email = "levi.waldron@sph.cuny.edu",
-        comment = c(ORCID = "0000-0003-2725-0694")
-    ))
+    person("Andres", "Wokaty", , "andres.wokaty@sph.cuny.edu", role = c("aut", "cre"),
+           comment = c(ORCID = "0009-0008-0900-8793")),
+    person("Levi", "Waldron", , "levi.waldron@sph.cuny.edu", role = "aut",
+           comment = c(ORCID = "0000-0003-2725-0694")),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "U24CA289073"))
+  )
 Description: A client for BEDbase. bedbaser provides access to the API at
     api.bedbase.org. It also includes convenience functions to import BED files
     into GRanges objects and BEDsets into GRangesLists.


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- U24CA289073

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23616447251](https://github.com/waldronlab/repo-audits/actions/runs/23616447251)).